### PR TITLE
chore: update media type texts

### DIFF
--- a/src/components/data-service-form/index.tsx
+++ b/src/components/data-service-form/index.tsx
@@ -794,7 +794,7 @@ const DataServiceForm = ({
             />
           </SC.Fieldset>
           <SC.Fieldset
-            title='Mediatyper'
+            title='Medietyper'
             subtitle={translations.mediaTypes.abstract}
             description={translations.mediaTypes.description}
             isReadOnly={isReadOnly}
@@ -806,8 +806,8 @@ const DataServiceForm = ({
                   name='mediaTypes'
                   labelText={
                     isReadOnly
-                      ? 'Registrerte mediatyper'
-                      : 'Velg blant registrerte mediatyper'
+                      ? 'Registrerte medietyper'
+                      : 'Søk på og velg blant registrerte medietyper'
                   }
                   value={values.mediaTypes.map(mediaType => {
                     const match = mediaTypes?.find(

--- a/src/l10n/helptexts.nb.ts
+++ b/src/l10n/helptexts.nb.ts
@@ -86,9 +86,9 @@ export const helptextsNb = {
   },
 
   mediaTypes: {
-    abstract: 'Velg format(er) fra IANAs liste over offisielle medietyper.',
+    abstract: 'Velg medietype(r) for API’et.',
     description:
-      'Skriv inn format og avlsutt med TAB eller Enter. Vi anbefaler at du bruker de samme formatbeskrivelsene som du finner i lenken nedenfor. (Obs: Du må selv kopiere over formatet fra listen.) Lenke til IANAs liste over offisielle medietyper: <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">http://www.iana.org/assignments/media-types/media-types.xhtml</a>'
+      'Listen kommer fra IANAs liste over offisielle medietyper: <a href="http://www.iana.org/assignments/media-types/media-types.xhtml">Media Types</a>. Se spesifikasjonen <a href="https://data.norge.no/specification/dcat-ap-no#Datatjeneste-medietype">Datatjeneste: medietype</a>'
   },
 
   isOpenAccess: {


### PR DESCRIPTION
@KurtStian Når jeg la til støtte for dct:format så følte jeg det også var behov noen tekstendringer på medietype feltet:
- Endrer mediatype til medietype på norske tekster, siden det er det som brukes i dcat-ap-no
- Reduserer abstract-teksten til å legne på den jeg la til på formats
- Endrer description teksten til å ligne på den jeg la til på formats, bør minimum fjerne det i teksten som henger igjen fra når det var et fritekst-felt

Ok?